### PR TITLE
Modifying instruction of installation

### DIFF
--- a/Modifying instruction of installation
+++ b/Modifying instruction of installation
@@ -1,0 +1,3 @@
+There was a confusion when I tried to install etherpad-lite on Windows. The second instruction of "With a "Run as administrator" command prompt execute bin\installOnWindows.bat" may make misunderstand to run their Command Prompt as 'Run as administrator'.
+
+The instruction can be replaced with "Open the folder of etherpad-lite, select bin, then run installOnWindows.bat.


### PR DESCRIPTION
There was a confusion when I tried to install etherpad-lite on Windows. The second instruction of "With a "Run as administrator" command prompt execute bin\installOnWindows.bat" may make misunderstand to run their Command Prompt as 'Run as administrator'.

The instruction can be replaced with "Open the folder of etherpad-lite, select bin, then run installOnWindows.bat.